### PR TITLE
use custom config path and use memory map files to speed up genomereference retrival

### DIFF
--- a/transvar/config.py
+++ b/transvar/config.py
@@ -55,7 +55,7 @@ def gunzip(fn):
 
     
 cfg_fns = [os.path.join(os.path.dirname(__file__), 'transvar.cfg'),
-           os.path.expanduser('~/.transvar.cfg')]
+           os.path.expanduser(os.getenv('TRANSVAR_CFG', '~/.transvar.cfg'))]
 
 downloaddirs = [os.path.join(os.path.dirname(__file__), 'transvar.download'),
                 os.path.expanduser('~/.transvar.download')]

--- a/transvar/faidx.py
+++ b/transvar/faidx.py
@@ -1,6 +1,9 @@
 """ faidx python code adapted from Allen Yu 
 http://www.allenyu.info/item/24-quickly-fetch-sequence-from-samtools-faidx-indexed-fasta-sequences.html """
 import sys
+
+import mmap
+
 from err import *
 from utils import *
 
@@ -10,8 +13,10 @@ class RefGenome:
         self.faidx = {}
          
         self.fasta_file=fasta_file
+
         try:
-            self.fasta_handle=open(fasta_file)
+            self.fasta_fd = open(fasta_file)
+            self.fasta_handle = mmap.mmap(self.fasta_fd.fileno(), 0, access=mmap.ACCESS_READ)
         except IOError:
             print "Reference sequence doesn't exist"
  
@@ -83,6 +88,10 @@ class RefGenome:
         
     def __exit__(self, type, value, traceback):
         self.fasta_handle.close()
+
+        if self.use_mmap:
+            self.fasta_fd.close()
+
         self.faidx_handle.close()
 
     def chrm2len(self, chrm):

--- a/transvar/faidx.py
+++ b/transvar/faidx.py
@@ -1,7 +1,6 @@
 """ faidx python code adapted from Allen Yu 
 http://www.allenyu.info/item/24-quickly-fetch-sequence-from-samtools-faidx-indexed-fasta-sequences.html """
 import sys
-
 import mmap
 
 from err import *
@@ -88,10 +87,7 @@ class RefGenome:
         
     def __exit__(self, type, value, traceback):
         self.fasta_handle.close()
-
-        if self.use_mmap:
-            self.fasta_fd.close()
-
+        self.fasta_fd.close()
         self.faidx_handle.close()
 
     def chrm2len(self, chrm):


### PR DESCRIPTION
This pull requests adds two small features:

1. If the user defines the OS environment variable "TRANSVAR_CFG", this path will be used instead of the default "~/.transvar.cfg"

2. Use memory map to speed up the genome reference retrival. We've tested and this speeds up transvar around ~10% when running big files.